### PR TITLE
add private field to output json

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ struct LcEvent {
 #[derive(Debug, Serialize, Deserialize)]
 struct OutputEvent {
     title: String,
+    public: bool,
     start_time: String,
     end_time: String,
     id: String,
@@ -271,6 +272,7 @@ impl LcSignage {
 
                 publish_events.push(OutputEvent {
                     title: event.title,
+                    public: event.public,
                     start_time: start_time.format("%l:%M %p").to_string(),
                     end_time: end_time.format("%l:%M %p").to_string(),
                     room: event


### PR DESCRIPTION
Adding the "private" field to the generated JSON file allows the end user to choose how to handle private reservations. This way the room can be clearly marked as "in use" without compromising the privacy of someone making a room reservation, or otherwise indicate that a reservation is made by a library user instead of a library staff member.