### PR TITLE
Improve base filtration by using `start` and `end` datetotime values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,7 @@ impl LcSignage {
                     .start_date
                     .split_whitespace()
                     .nth(1)
-                    .ok_or("could not read JSON time/date")?,
+                    .ok_or(anyhow!("could not read JSON time/date"))?,
                 "%H:%M:%S",
             )?;
 
@@ -262,7 +262,7 @@ impl LcSignage {
                     .end_date
                     .split_whitespace()
                     .nth(1)
-                    .ok_or("could not split end date string")?,
+                    .ok_or(anyhow!("could not split end date string"))?,
                 "%H:%M:%S",
             )?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,10 +151,10 @@ impl ConnectionData {
             for rm in room_split {
                 room_str = format!("{room_str}&rooms[{rm}]={rm}");
             }
-            format!("{}{}&start=today&end=tomorrow", self.feed_url, room_str)
+            format!("{}{}&start=now&end=tomorrow", self.feed_url, room_str)
         } else {
             format!(
-                "{}?rooms[{}]={}&start=today&end=tomorrow",
+                "{}?rooms[{}]={}&start=now&end=tomorrow",
                 self.feed_url, room, room
             )
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,10 +248,10 @@ impl LcSignage {
 
         for event in events {
             let mut time_str = event.start_date.split_whitespace();
-            // let scheduled_date = NaiveDate::parse_from_str(
-            //     time_str.next().ok_or("could not read JSON time/date")?,
-            //     "%Y-%m-%d",
-            // )?;
+            let scheduled_date = NaiveDate::parse_from_str(
+                time_str.next().ok_or("could not read JSON time/date")?,
+                "%Y-%m-%d",
+            )?;
 
             // if scheduled_date == today {
             let start_time = NaiveTime::parse_from_str(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,9 +151,12 @@ impl ConnectionData {
             for rm in room_split {
                 room_str = format!("{room_str}&rooms[{rm}]={rm}");
             }
-            format!("{}{}", self.feed_url, room_str)
+            format!("{}{}", self.feed_url, room_str, "&start=today&end=tomorrow")
         } else {
-            format!("{}?rooms[{}]={}", self.feed_url, room, room)
+            format!(
+                "{}?rooms[{}]={}",
+                self.feed_url, room, room, "&start=today&end=tomorrow"
+            )
         };
 
         Ok(url)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@ use std::{
     time::Instant,
 };
 
-use anyhow::Context;
-use chrono::{NaiveDate, NaiveTime};
+use anyhow::{anyhow, Context};
+use chrono::NaiveTime;
 use home::home_dir;
 use log::error;
 use oauth2::{
@@ -244,7 +244,6 @@ impl LcSignage {
     /// The `HashMap` is keyed by the room ID number and is dynamically generated.
     fn generate_room_events(events: Vec<LcEvent>) -> Result<Vec<OutputEvent>> {
         let mut publish_events = vec![];
-        let today = chrono::Local::now().date_naive();
 
         for event in events {
             // if scheduled_date == today {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,49 +244,40 @@ impl LcSignage {
     /// The `HashMap` is keyed by the room ID number and is dynamically generated.
     fn generate_room_events(events: Vec<LcEvent>) -> Result<Vec<OutputEvent>> {
         let mut publish_events = vec![];
-        let today = chrono::Local::now().date_naive();
 
         for event in events {
             let mut time_str = event.start_date.split_whitespace();
-            let scheduled_date = NaiveDate::parse_from_str(
+
+            let start_time = NaiveTime::parse_from_str(
                 time_str.next().ok_or("could not read JSON time/date")?,
-                "%Y-%m-%d",
+                "%H:%M:%S",
             )?;
 
-            if scheduled_date == today {
-                let start_time = NaiveTime::parse_from_str(
-                    time_str.next().ok_or("could not read JSON time/date")?,
-                    "%H:%M:%S",
-                )?;
+            let end_time = NaiveTime::parse_from_str(
+                event
+                    .end_date
+                    .split_whitespace()
+                    .nth(1)
+                    .ok_or("could not split end date string")?,
+                "%H:%M:%S",
+            )?;
 
-                let end_time = NaiveTime::parse_from_str(
-                    event
-                        .end_date
-                        .split_whitespace()
-                        .nth(1)
-                        .ok_or("could not split end date string")?,
-                    "%H:%M:%S",
-                )?;
-
-                publish_events.push(OutputEvent {
-                    title: event.title,
-                    public: event.public,
-                    start_time: start_time.format("%l:%M %p").to_string(),
-                    end_time: end_time.format("%l:%M %p").to_string(),
-                    room: event
-                        .room
-                        .as_object()
-                        .unwrap()
-                        .keys()
-                        .next()
-                        .unwrap()
-                        .to_owned(),
-                    id: event.id,
-                    moderation_state: event.moderation_state,
-                });
-            } else {
-                break;
-            }
+            publish_events.push(OutputEvent {
+                title: event.title,
+                public: event.public,
+                start_time: start_time.format("%l:%M %p").to_string(),
+                end_time: end_time.format("%l:%M %p").to_string(),
+                room: event
+                    .room
+                    .as_object()
+                    .unwrap()
+                    .keys()
+                    .next()
+                    .unwrap()
+                    .to_owned(),
+                id: event.id,
+                moderation_state: event.moderation_state,
+            });
         }
 
         Ok(publish_events)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,11 +151,11 @@ impl ConnectionData {
             for rm in room_split {
                 room_str = format!("{room_str}&rooms[{rm}]={rm}");
             }
-            format!("{}{}", self.feed_url, room_str, "&start=today&end=tomorrow")
+            format!("{}{}&start=today&end=tomorrow", self.feed_url, room_str)
         } else {
             format!(
-                "{}?rooms[{}]={}",
-                self.feed_url, room, room, "&start=today&end=tomorrow"
+                "{}?rooms[{}]={}&start=today&end=tomorrow",
+                self.feed_url, room, room
             )
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,45 +248,45 @@ impl LcSignage {
 
         for event in events {
             let mut time_str = event.start_date.split_whitespace();
-            let scheduled_date = NaiveDate::parse_from_str(
+            // let scheduled_date = NaiveDate::parse_from_str(
+            //     time_str.next().ok_or("could not read JSON time/date")?,
+            //     "%Y-%m-%d",
+            // )?;
+
+            // if scheduled_date == today {
+            let start_time = NaiveTime::parse_from_str(
                 time_str.next().ok_or("could not read JSON time/date")?,
-                "%Y-%m-%d",
+                "%H:%M:%S",
             )?;
 
-            if scheduled_date == today {
-                let start_time = NaiveTime::parse_from_str(
-                    time_str.next().ok_or("could not read JSON time/date")?,
-                    "%H:%M:%S",
-                )?;
+            let end_time = NaiveTime::parse_from_str(
+                event
+                    .end_date
+                    .split_whitespace()
+                    .nth(1)
+                    .ok_or("could not split end date string")?,
+                "%H:%M:%S",
+            )?;
 
-                let end_time = NaiveTime::parse_from_str(
-                    event
-                        .end_date
-                        .split_whitespace()
-                        .nth(1)
-                        .ok_or("could not split end date string")?,
-                    "%H:%M:%S",
-                )?;
-
-                publish_events.push(OutputEvent {
-                    title: event.title,
-                    public: event.public,
-                    start_time: start_time.format("%l:%M %p").to_string(),
-                    end_time: end_time.format("%l:%M %p").to_string(),
-                    room: event
-                        .room
-                        .as_object()
-                        .unwrap()
-                        .keys()
-                        .next()
-                        .unwrap()
-                        .to_owned(),
-                    id: event.id,
-                    moderation_state: event.moderation_state,
-                });
-            } else {
-                break;
-            }
+            publish_events.push(OutputEvent {
+                title: event.title,
+                public: event.public,
+                start_time: start_time.format("%l:%M %p").to_string(),
+                end_time: end_time.format("%l:%M %p").to_string(),
+                room: event
+                    .room
+                    .as_object()
+                    .unwrap()
+                    .keys()
+                    .next()
+                    .unwrap()
+                    .to_owned(),
+                id: event.id,
+                moderation_state: event.moderation_state,
+            });
+            // } else {
+            //     break;
+            // }
         }
 
         Ok(publish_events)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,13 +147,13 @@ impl ConnectionData {
             let first_room = room_split
                 .next()
                 .context("expected a room number in substring")?;
-            let mut room_str = format!("?rooms[{first_room}]={first_room}");
+            let mut room_str = format!("&rooms[{first_room}]={first_room}");
             for rm in room_split {
                 room_str = format!("{room_str}&rooms[{rm}]={rm}");
             }
             format!("{}{}", self.query_url, room_str)
         } else {
-            format!("{}?rooms[{}]={}", self.query_url, room, room)
+            format!("{}&rooms[{}]={}", self.query_url, room, room)
         };
 
         Ok(url)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,7 +248,7 @@ impl LcSignage {
 
         for event in events {
             let mut time_str = event.start_date.split_whitespace();
-            let scheduled_date = NaiveDate::parse_from_str(
+            let _scheduled_date = NaiveDate::parse_from_str(
                 time_str.next().ok_or("could not read JSON time/date")?,
                 "%Y-%m-%d",
             )?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ struct OutputEvent {
 pub struct ConnectionData {
     oauth_url: String,
     token_url: String,
-    feed_url: String,
+    query_url: String,
     client_id: String,
     client_secret: String,
     access_token: String,
@@ -90,7 +90,7 @@ impl ConnectionData {
         Self {
             oauth_url,
             token_url,
-            feed_url,
+            query_url: feed_url,
             client_id,
             client_secret,
             save_path,
@@ -151,12 +151,9 @@ impl ConnectionData {
             for rm in room_split {
                 room_str = format!("{room_str}&rooms[{rm}]={rm}");
             }
-            format!("{}{}&start=now&end=tomorrow", self.feed_url, room_str)
+            format!("{}{}", self.query_url, room_str)
         } else {
-            format!(
-                "{}?rooms[{}]={}&start=now&end=tomorrow",
-                self.feed_url, room, room
-            )
+            format!("{}?rooms[{}]={}", self.query_url, room, room)
         };
 
         Ok(url)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,15 +247,13 @@ impl LcSignage {
         let today = chrono::Local::now().date_naive();
 
         for event in events {
-            let mut time_str = event.start_date.split_whitespace();
-            let _scheduled_date = NaiveDate::parse_from_str(
-                time_str.next().ok_or("could not read JSON time/date")?,
-                "%Y-%m-%d",
-            )?;
-
             // if scheduled_date == today {
             let start_time = NaiveTime::parse_from_str(
-                time_str.next().ok_or("could not read JSON time/date")?,
+                event
+                    .start_date
+                    .split_whitespace()
+                    .nth(1)
+                    .ok_or("could not read JSON time/date")?,
                 "%H:%M:%S",
             )?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use std::{
-    path::PathBuf,
     thread::sleep,
     time::{Duration, Instant},
 };
@@ -56,12 +55,16 @@ async fn main() -> Result<()> {
             } else {
                 None
             };
+            let query_start_time = cfg.get_string("start_time").unwrap_or("now".into());
+            let query_end_time = cfg.get_string("end_time").unwrap_or("tomorrow".into());
+
+            let query_url = format!("{feed_url}?start={query_start_time}&end={query_end_time}");
 
             // setup service structs
             let connection = ConnectionData::new(
                 oauth_url,
                 token_url,
-                feed_url,
+                query_url,
                 client_id,
                 client_secret,
                 save_path,


### PR DESCRIPTION
Baseline functionality for `start` and `end` datetotime values hardcoded in system software.