### PR TITLE
Add `env_logger` as default logging system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +57,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -189,6 +248,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "config"
@@ -346,6 +411,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -628,6 +716,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -918,6 +1012,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,6 +1051,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "config",
+ "env_logger",
  "home",
  "log",
  "oauth2",
@@ -1318,6 +1419,35 @@ checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
 dependencies = [
  "bitflags 2.8.0",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -2095,6 +2225,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,16 @@ oauth2 = { version = "4.4.2", features = ["curl"] }
 anyhow = "1.0.91"
 chrono = "0.4.38"
 home = "0.5.9"
-systemd-journal-logger = "2.2.0"
+systemd-journal-logger = {version = "2.2.0", optional = true}
 log = "0.4.22"
 config = { version = "0.15.0", features = ["toml"] }
 reqwest = {version ="0.12.8", features = ["json"] }
+env_logger = {version = "0.11.6", optional = true}
 
 [lints.clippy]
 pedantic = "warn"
+
+[features]
+default = ["cross_platform"]
+cross_platform = ["env_logger"]
+systemd = ["systemd-journal-logger"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use std::{
     time::Instant,
 };
 
-use anyhow::{anyhow, Context};
+use anyhow::{Context, anyhow};
 use chrono::NaiveTime;
 use home::home_dir;
 use log::error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ async fn main() -> Result<()> {
 
 #[cfg(feature = "cross_platform")]
 fn install_logger() {
-    env_logger::init();
+    env_logger::builder().filter_level(LevelFilter::Info).init();
 }
 
 #[cfg(feature = "systemd")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ use std::{
 use anyhow::{Context, anyhow};
 use config::Config;
 use log::{LevelFilter, error, info};
-use systemd_journal_logger::JournalLog;
 
 // Type alias for tokio return types
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
@@ -23,7 +22,8 @@ use lc_signage::{ConnectionData, LcSignage};
 #[tokio::main]
 async fn main() -> Result<()> {
     // setup systemd journal logging
-    JournalLog::new().unwrap().install().unwrap();
+    install_logger();
+
     log::set_max_level(LevelFilter::Info);
 
     let config_location = home::home_dir().unwrap();
@@ -101,4 +101,17 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(feature = "cross_platform")]
+fn install_logger() {
+    env_logger::init();
+}
+
+#[cfg(feature = "systemd")]
+fn install_logger() {
+    systemd_journal_logger::JournalLog::new()
+        .unwrap()
+        .install()
+        .unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,15 +103,14 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "cross_platform")]
 fn install_logger() {
-    env_logger::builder().filter_level(LevelFilter::Info).init();
-}
-
-#[cfg(feature = "systemd")]
-fn install_logger() {
-    systemd_journal_logger::JournalLog::new()
-        .unwrap()
-        .install()
-        .unwrap();
+    if cfg!(feature = "cross_platform") && !cfg!(feature = "systemd") {
+        env_logger::builder().filter_level(LevelFilter::Info).init();
+    } else if cfg!(feature = "systemd") {
+        #[cfg(feature = "systemd")]
+        systemd_journal_logger::JournalLog::new()
+            .unwrap()
+            .install()
+            .unwrap();
+    }
 }


### PR DESCRIPTION
Remove dependency on systemd logging and enable the cross-platform `env_logger` interface as default logging method.